### PR TITLE
Remove direct estimagic dependencies to avoid circular imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ black = 1
 filterwarnings = [
     "ignore:delta_grad == 0.0",  # UserWarning in test_poisedness.py
     "ignore:Jupyter is migrating",  # DeprecationWarning from jupyter client
+    "ignore:Noisy scalar functions are experimental",
 ]
 markers = [
     "wip: Tests that are work-in-progress.",

--- a/src/tranquilo/__init__.py
+++ b/src/tranquilo/__init__.py
@@ -1,4 +1,0 @@
-from tranquilo.tranquilo import tranquilo, tranquilo_ls
-
-
-__all__ = ["tranquilo", "tranquilo_ls"]

--- a/src/tranquilo/options.py
+++ b/src/tranquilo/options.py
@@ -184,7 +184,7 @@ class FilterOptions(NamedTuple):
 class SamplerOptions(NamedTuple):
     distribution: str = None
     hardness: float = 1
-    algorithm: str = "scipy_lbfgsb"
+    algorithm: str = "L-BFGS-B"
     algo_options: dict = None
     criterion: str = None
     n_points_randomsearch: int = 1

--- a/src/tranquilo/process_arguments.py
+++ b/src/tranquilo/process_arguments.py
@@ -29,6 +29,7 @@ from tranquilo.region import Region
 from tranquilo.sample_points import get_sampler
 from tranquilo.solve_subproblem import get_subsolver
 from tranquilo.wrap_criterion import get_wrapped_criterion
+import warnings
 
 
 def process_arguments(
@@ -86,6 +87,26 @@ def process_arguments(
     infinity_handler="relative",
     residualize=None,
 ):
+    # warning for things that do not work well yet
+    if noisy and functype == "scalar":
+        msg = (
+            "Noisy scalar functions are experimental and likely to give very "
+            "suboptimal results."
+        )
+        warnings.warn(msg)
+    if noisy and n_cores > 1:
+        msg = (
+            "Parallelization together with noisy functions is experimental and likely "
+            "to give very suboptimal results."
+        )
+        warnings.warn(msg)
+    if n_cores > 1 and functype == "scalar":
+        msg = (
+            "Parallelization together with scalar functions is experimental and likely "
+            "to give very suboptimal results."
+        )
+        warnings.warn(msg)
+
     # process convergence options
     conv_options = ConvOptions(
         disable=bool(disable_convergence),

--- a/src/tranquilo/process_arguments.py
+++ b/src/tranquilo/process_arguments.py
@@ -1,9 +1,5 @@
 import numpy as np
 
-from estimagic.optimization.algo_options import (
-    CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
-    CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
-)
 from tranquilo.acceptance_decision import get_acceptance_decider
 from tranquilo.aggregate_models import get_aggregator
 from tranquilo.bounds import Bounds
@@ -51,8 +47,8 @@ def process_arguments(
     convergence_absolute_criterion_tolerance=0.0,
     convergence_absolute_gradient_tolerance=0.0,
     convergence_absolute_params_tolerance=0.0,
-    convergence_relative_criterion_tolerance=CONVERGENCE_RELATIVE_CRITERION_TOLERANCE,
-    convergence_relative_gradient_tolerance=CONVERGENCE_RELATIVE_GRADIENT_TOLERANCE,
+    convergence_relative_criterion_tolerance=2e-9,
+    convergence_relative_gradient_tolerance=1e-8,
     convergence_relative_params_tolerance=1e-8,
     convergence_min_trust_region_radius=0.0,
     # stopping options

--- a/src/tranquilo/tranquilo.py
+++ b/src/tranquilo/tranquilo.py
@@ -1,10 +1,8 @@
 import functools
-from functools import partial
 from typing import NamedTuple
 
 import numpy as np
 
-from estimagic.decorators import mark_minimizer
 from tranquilo.adjust_radius import adjust_radius
 from tranquilo.filter_points import (
     drop_worst_points,
@@ -511,25 +509,6 @@ def _is_converged(states, options):
         msg = None
 
     return converged, msg
-
-
-tranquilo = mark_minimizer(
-    func=partial(_tranquilo, functype="scalar"),
-    name="tranquilo",
-    primary_criterion_entry="value",
-    needs_scaling=True,
-    is_available=True,
-    is_global=False,
-)
-
-tranquilo_ls = mark_minimizer(
-    func=partial(_tranquilo, functype="least_squares"),
-    primary_criterion_entry="root_contributions",
-    name="tranquilo_ls",
-    needs_scaling=True,
-    is_available=True,
-    is_global=False,
-)
 
 
 def _concatenate_indices(first, second):

--- a/src/tranquilo/wrap_criterion.py
+++ b/src/tranquilo/wrap_criterion.py
@@ -2,8 +2,6 @@ import functools
 
 import numpy as np
 
-from estimagic.batch_evaluators import process_batch_evaluator
-
 
 def get_wrapped_criterion(criterion, batch_evaluator, n_cores, history):
     """Wrap the criterion function to do get parallelization and history handling.
@@ -66,3 +64,24 @@ def get_wrapped_criterion(criterion, batch_evaluator, n_cores, history):
         )
 
     return wrapper_criterion
+
+
+def process_batch_evaluator(batch_evaluator="joblib"):
+    batch_evaluator = "joblib" if batch_evaluator is None else batch_evaluator
+
+    if callable(batch_evaluator):
+        out = batch_evaluator
+    elif isinstance(batch_evaluator, str):
+        if batch_evaluator == "joblib":
+            from estimagic.batch_evaluators import joblib_batch_evaluator as out
+        elif batch_evaluator == "pathos":
+            from estimagic.batch_evaluators import pathos_mp_batch_evaluator as out
+        else:
+            raise ValueError(
+                "Invalid batch evaluator requested. Currently only 'pathos' and "
+                "'joblib' are supported."
+            )
+    else:
+        raise TypeError("batch_evaluator must be a callable or string.")
+
+    return out

--- a/tests/subsolvers/test_gqtpar_lambdas.py
+++ b/tests/subsolvers/test_gqtpar_lambdas.py
@@ -1,6 +1,18 @@
-import estimagic as em
+from estimagic.optimization.optimize import minimize
 from estimagic.benchmarking.get_benchmark_problems import get_benchmark_problems
-from tranquilo import tranquilo
+from tranquilo.tranquilo import _tranquilo
+from estimagic.decorators import mark_minimizer
+from functools import partial
+
+
+tranquilo = mark_minimizer(
+    func=partial(_tranquilo, functype="scalar"),
+    name="tranquilo",
+    primary_criterion_entry="value",
+    needs_scaling=True,
+    is_available=True,
+    is_global=False,
+)
 
 
 def test_gqtpar_lambdas():
@@ -13,7 +25,7 @@ def test_gqtpar_lambdas():
     }
     problem_info = get_benchmark_problems("more_wild")["freudenstein_roth_good_start"]
 
-    em.minimize(
+    minimize(
         criterion=problem_info["inputs"]["criterion"],
         params=problem_info["inputs"]["params"],
         algo_options=algo_options,

--- a/tests/test_fit_models.py
+++ b/tests/test_fit_models.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from estimagic import first_derivative, second_derivative
+from estimagic.differentiation.derivatives import first_derivative, second_derivative
 from tranquilo.fit_models import _quadratic_features, get_fitter
 from tranquilo.region import Region
 from numpy.testing import assert_array_almost_equal, assert_array_equal

--- a/tests/test_tranquilo.py
+++ b/tests/test_tranquilo.py
@@ -3,11 +3,31 @@ import itertools
 import numpy as np
 import pytest
 from estimagic.optimization.optimize import minimize
-from tranquilo.tranquilo import (
-    tranquilo,
-    tranquilo_ls,
-)
+from tranquilo.tranquilo import _tranquilo
 from numpy.testing import assert_array_almost_equal as aaae
+from estimagic.decorators import mark_minimizer
+from functools import partial
+
+
+tranquilo = mark_minimizer(
+    func=partial(_tranquilo, functype="scalar"),
+    name="tranquilo",
+    primary_criterion_entry="value",
+    needs_scaling=True,
+    is_available=True,
+    is_global=False,
+)
+
+
+tranquilo_ls = mark_minimizer(
+    func=partial(_tranquilo, functype="least_squares"),
+    primary_criterion_entry="root_contributions",
+    name="tranquilo_ls",
+    needs_scaling=True,
+    is_available=True,
+    is_global=False,
+)
+
 
 # ======================================================================================
 # Test tranquilo end-to-end

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,7 +1,30 @@
 import pytest
-from estimagic import get_benchmark_problems, minimize
+from estimagic.optimization.optimize import minimize
+from estimagic.benchmarking.get_benchmark_problems import get_benchmark_problems
 from tranquilo.visualize import visualize_tranquilo
-from tranquilo import tranquilo, tranquilo_ls
+from tranquilo.tranquilo import _tranquilo
+from estimagic.decorators import mark_minimizer
+from functools import partial
+
+
+tranquilo = mark_minimizer(
+    func=partial(_tranquilo, functype="scalar"),
+    name="tranquilo",
+    primary_criterion_entry="value",
+    needs_scaling=True,
+    is_available=True,
+    is_global=False,
+)
+
+
+tranquilo_ls = mark_minimizer(
+    func=partial(_tranquilo, functype="least_squares"),
+    primary_criterion_entry="root_contributions",
+    name="tranquilo_ls",
+    needs_scaling=True,
+    is_available=True,
+    is_global=False,
+)
 
 cases = []
 algo_options = {


### PR DESCRIPTION
## Remove direct estimagic dependencies to avoid circular imports

- [x] Use scipy minimize in optimal sampling 
- [x] Write custom process batch evaluator
- [x] Hardcode some algo options
- [x] Look at benchmarks

The benchmarks change slightly. This is expected, as the optimization in the optimal sampler changed:
- scipy numerical derivative instead of estimagics's
- slightly different convergence criteria

I think we can ignore this. The changes are smaller than differences we get between computers. 

## Old parallel ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/dd13b76c-e1dc-4896-9c63-2e9d3db83ecb)

## New parallel ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/74cf36fd-fcff-44a0-bd15-e02e9689dbe5)

## Old noisy ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/5bf9c044-b1ef-4d87-9ca2-4a91adede1cc)

## New noisy ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/b9739831-dc64-45e4-9106-09a7d3758644)

## Old ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/60ea70da-a579-4c0c-af7d-691dfef45b13)

## New ls

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/eca71e43-2678-4f5c-9502-3efe333e66e3)

## Old scalar

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/38ae1f56-653d-4650-90af-7fc417a9d9ca)

## New scalar

![image](https://github.com/OpenSourceEconomics/tranquilo/assets/9536380/7e49fbd5-6d0d-418c-afbb-049c87db897b)



