### PR TITLE
Parallelism2

### DIFF
--- a/tests/test_acceptance_decision.py
+++ b/tests/test_acceptance_decision.py
@@ -185,7 +185,8 @@ def test_generate_speculative_sample():
         sample_points=get_sampler("random_hull"),
         n_points=3,
         history=history,
-        radius_factor=1.0,
+        search_radius_factor=5.0,
+        sample_radius_factor=1.0,
         line_search_xs=None,
         rng=np.random.default_rng(1234),
     )


### PR DESCRIPTION
What we did:

- Differentiate between search radius factor and sample radius factor in speculative sampling

What happened:

- Benchmark results got slightly worse (especially for 4 and 8 cores)

What we want to do:

*General idea:* Make speculative sampling resemble sampling step after acceptance decision

- Tune search radius factor for parallel optimizer
- Use filter on existing points in speculative sampling 